### PR TITLE
test(file_storage): fix tests broken by changed constructor behaviour

### DIFF
--- a/tests/test_models/test_engine/test_file_storage.py
+++ b/tests/test_models/test_engine/test_file_storage.py
@@ -28,11 +28,10 @@ class test_fileStorage(unittest.TestCase):
         """ __objects is initially empty """
         self.assertEqual(len(storage.all()), 0)
 
-    @unittest.skip("A bare constructor no longer adds to the storage \
-                    dictionary, which breaks the test.")
     def test_new(self):
         """ New object is correctly added to __objects """
         new = BaseModel()
+        new.save()
         for obj in storage.all().values():
             temp = obj
         self.assertTrue(temp is obj)
@@ -62,11 +61,10 @@ class test_fileStorage(unittest.TestCase):
         storage.save()
         self.assertTrue(os.path.exists('file.json'))
 
-    @unittest.skip("A bare constructor no longer adds to the storage \
-                    dictionary, which breaks the test.")
     def test_reload(self):
         """ Storage file is successfully loaded to __objects """
         new = BaseModel()
+        new.save()
         storage.save()
         storage.reload()
         for obj in storage.all().values():
@@ -98,11 +96,10 @@ class test_fileStorage(unittest.TestCase):
         """ Confirm __objects is a dict """
         self.assertEqual(type(storage.all()), dict)
 
-    @unittest.skip("A bare constructor no longer adds to the storage \
-                    dictionary, which breaks the test.")
     def test_key_format(self):
         """ Key is properly formatted """
         new = BaseModel()
+        new.save()
         _id = new.to_dict()['id']
         for key in storage.all().keys():
             temp = key


### PR DESCRIPTION
When the [constructor behaviour was changed](https://github.com/haoningng/holbertonschool-AirBnB_clone_v2/commit/735cf69f9cdfb309d0f3e550046c887d9a906d58#diff-7c1ece53a18959b293126dd93f3cf0f768220f50d2c1201e1601681873e6f6e4L16) to satisfy Task 6's requirements, [some file storage tests broke](https://github.com/haoningng/holbertonschool-AirBnB_clone_v2/commit/389579ec3ce0b91251b65e402e595468b41b864f). This commit fixes those broken tests by ensuring that instances created in the test are added to storage. 

If the instances are not added to storage, an `UnboundLocalError` will occur because `storage.all()` will be empty and the `for` loop body in each of the tests will not iterate; consequently, the assignment expression inside the `for` loop will never bind a value to the variable name. This error was the original reason the tests were skipped - as a stop gap until the test logic could be updated to reflect the changed behaviour of the `BaseModel` constructor. This commit is the update to the test logic that was pending, and now they no longer need to be skipped.